### PR TITLE
update subscription response, instead of symbol we need to have message

### DIFF
--- a/protos/onyx_otc/v2/responses.proto
+++ b/protos/onyx_otc/v2/responses.proto
@@ -57,7 +57,7 @@ message Order {
 
 message Subscription {
   Channel channel = 1;
-  string symbol = 2;
+  string message = 2;
   SubscriptionStatus status = 4;
 }
 


### PR DESCRIPTION
This PR does the following
- Make sure we add message to subscription instead of just symbol