### PR TITLE
Reserve reverted #44 proto slots; move notification fields off them

### DIFF
--- a/protos/onyx_otc/v2/requests.proto
+++ b/protos/onyx_otc/v2/requests.proto
@@ -52,6 +52,7 @@ message Auth {
 message NotificationsChannel {}
 
 message Subscribe {
+  reserved 7;  // dy_ticker (#44, reverted)
   oneof channel {
     ServerInfoChannel server_info = 1;
     OrdersChannel orders = 2;
@@ -59,11 +60,12 @@ message Subscribe {
     RfqChannel rfq_channel = 4;
     OrderBookTopChannel order_book_top = 5;
     OrderBookChannel order_book = 6;
-    NotificationsChannel notifications = 7;
+    NotificationsChannel notifications = 8;
   }
 }
 
 message Unsubscribe {
+  reserved 7;  // dy_ticker (#44, reverted)
   oneof channel {
     ServerInfoChannel server_info = 1;
     OrdersChannel orders = 2;
@@ -71,7 +73,7 @@ message Unsubscribe {
     RfqChannel rfq_channel = 4;
     OrderBookTopChannel order_book_top = 5;
     OrderBookChannel order_book = 6;
-    NotificationsChannel notifications = 7;
+    NotificationsChannel notifications = 8;
   }
 }
 

--- a/protos/onyx_otc/v2/responses.proto
+++ b/protos/onyx_otc/v2/responses.proto
@@ -169,6 +169,7 @@ message Notifications {
 message ChannelMessage {
   Channel channel = 1;
   google.protobuf.Timestamp timestamp = 2;
+  reserved 14;  // dy_tickers (#44, reverted)
   oneof message {
     Order order = 8;
     ServerInfo server_info = 9;
@@ -176,8 +177,8 @@ message ChannelMessage {
     OtcQuote otc_quote = 11;
     OrderBookTops order_book_tops = 12;
     OrderBooks order_books = 13;
-    Notification notification = 14;
-    Notifications notifications = 15;
+    Notification notification = 16;
+    Notifications notifications = 17;
   }
 }
 

--- a/protos/onyx_otc/v2/types.proto
+++ b/protos/onyx_otc/v2/types.proto
@@ -89,7 +89,8 @@ enum Channel {
   CHANNEL_RFQ = 4;
   CHANNEL_ORDER_BOOK_TOP = 5;
   CHANNEL_ORDER_BOOK = 6;
-  CHANNEL_NOTIFICATIONS = 7;
+  reserved 7;  // CHANNEL_DY_TICKERS (#44, reverted)
+  CHANNEL_NOTIFICATIONS = 8;
 }
 
 enum NotificationKind {


### PR DESCRIPTION
## Problem
`#46` was squash-merged with the branch's `Revert "#44"`, which (a) removed the #44 dynamic-pricer proto from `main` and (b) parked the notification channel on the exact field numbers #44 had used (Subscribe/Unsubscribe oneof `7`, `ChannelMessage` `14`/`15`, `Channel` enum `7`). Reusing reverted field numbers is a wire hazard for when #44 returns.

## Fix
#44 stays out for now; reserve its slots and move notifications off them:

| file | change |
|---|---|
| requests.proto | Subscribe + Unsubscribe: `reserved 7` (dy_ticker, #44); `notifications` 7 -> 8 |
| responses.proto | ChannelMessage: `reserved 14` (dy_tickers, #44); `notification` 14 -> 16, `notifications` 15 -> 17 |
| types.proto | Channel enum: `reserved 7` (CHANNEL_DY_TICKERS, #44); `CHANNEL_NOTIFICATIONS` 7 -> 8 |

## Validation
`buf build`, `buf lint`, and `protoc` parse all pass. Not yet released, so renumbering is safe.